### PR TITLE
Replace apache 2.2 directives in shib_table config example

### DIFF
--- a/shib_table_auth.conf
+++ b/shib_table_auth.conf
@@ -1,7 +1,7 @@
 # Allow but do not *require* Shibboleth for a REDCap instance
 # This configuration is compatible with UF's shib-table authentication method
 
-# Instance name is "stage_c". Change this string to suit your need. 
+# Instance name is "stage_c". Change this string to suit your need.
 # If your REDCap is installed at the root of your host, remove '^/stage_c' from the locations below
 
 <Location ~ "^/stage_c">
@@ -9,9 +9,10 @@
  ShibRequireSession Off
  require shibboleth
  ShibUseHeaders Off
- Order allow,deny
- Allow from 127.0.0.1
- Satisfy any
+ <RequireAny>
+   require valid-user
+   require ip 127.0.0.1
+ </RequireAny>
 </Location>
 
 # Allow access to External Modules


### PR DESCRIPTION
The Apache 2.2 directives are deprecated. They generate lots of distracting error messages in the apache error log. This PR modernizes the directives using Apache 2.4 modules and their directives.